### PR TITLE
Retry logic + logs

### DIFF
--- a/src-dfu/NrfDfuServer.cpp
+++ b/src-dfu/NrfDfuServer.cpp
@@ -5,14 +5,15 @@
 #include <sstream>
 #include "crc.h"
 
-static std::string ToHex(const std::string &s, bool upper_case) {  // Used for debugging
-    std::ostringstream ret;
-    for (std::string::size_type i = 0; i < s.length(); ++i) {
-        int z = s[i] & 0xff;
-        ret << std::hex << std::setfill('0') << std::setw(2) << (upper_case ? std::uppercase : std::nouppercase) << z;
-    }
-    return ret.str();
-}
+// Comment out when not debugging to avoid defined but not used compiler warnings
+// static std::string ToHex(const std::string &s, bool upper_case) {  // Used for debugging
+//     std::ostringstream ret;
+//     for (std::string::size_type i = 0; i < s.length(); ++i) {
+//         int z = s[i] & 0xff;
+//         ret << std::hex << std::setfill('0') << std::setw(2) << (upper_case ? std::uppercase : std::nouppercase) << z;
+//     }
+//     return ret.str();
+// }
 
 using namespace NativeDFU;
 
@@ -216,6 +217,8 @@ void NrfDfuServer::manage_state() {
             break;
 
         case DFU_FINISHED:
+        case DFU_ERROR:
+        case DFU_ERROR_CHECKSUM:
             break;
     }
 }
@@ -288,11 +291,21 @@ void NrfDfuServer::event_handler() {
         case BINFILE_REQ_CHECKSUM:
             if (this->received_event == CHECKSUM_RECEIVED) {
                 if (this->checksum_match()) {
+                    this->bin_retries = 0;
                     this->state = BINFILE_WRITE_EXECUTE;
                     // std::cout << "Received checksum: 0x" << std::hex << std::setfill('0') << std::setw(2)
                     //           << this->response.resp_val.checksum.crc32 << std::endl;
                 } else {
-                    this->state = DFU_ERROR_CHECKSUM;
+                    // Retry logic: on a failed CRC, return bin buffer pointer to start of object
+                    // and return to BINFILE_CREATE_DATA_OBJ state. If number of retries exceeds
+                    // max retires, put FSM into error state
+                    if (this->bin_retries < MAX_RETRIES) {
+                        this->bin_retries++;
+                        this->bin_bytes_written -= this->bin_bytes_to_write; // Resets bin pointer to previous object
+                        this->state = BINFILE_CREATE_DATA_OBJ;
+                    } else {
+                        this->state = DFU_ERROR_CHECKSUM;
+                    }
                     // std::cout << "Invalid Checksum" << std::endl;
                 }
             } else {
@@ -319,6 +332,8 @@ void NrfDfuServer::event_handler() {
             break;
 
         case DFU_FINISHED:
+        case DFU_ERROR:
+        case DFU_ERROR_CHECKSUM:
             break;
     }
     this->waiting_response = false;

--- a/src-dfu/NrfDfuServer.h
+++ b/src-dfu/NrfDfuServer.h
@@ -233,6 +233,8 @@ class NrfDfuServer {
     uint32_t mtu_chunks_remaining;
     bool mtu_last_chunk;
 
+    uint32_t bin_retries;
+
     // * CRC Result is calculated and stored here before sending data
     uint32_t crc32_result;
 

--- a/src-dfu/NrfDfuServerTypes.h
+++ b/src-dfu/NrfDfuServerTypes.h
@@ -15,6 +15,9 @@
 #define RESPONSE_LEN_CHECKSUM 8
 #define RESPONSE_LEN_SELECT 12
 
+// Retry sending a DFU object on a CRC failure
+#define MAX_RETRIES 5
+
 namespace NativeDFU {
 
 typedef std::function<void(std::string service, std::string characteristic, std::string data)> ble_write_t;


### PR DESCRIPTION
Changes:
- On a failed CRC, retry sending the DFU object up to 5 times. Much more robust than exiting on first failed CRC. 
- Add logs to main module to track DFU progress.
- Code cleanliness changes (comment out unused function, add all cases to switch) that avoid compiler warnings.

Cheers!